### PR TITLE
#46 Region filtering: Only enabled regions (opted-in or not-required)…

### DIFF
--- a/provider/aws.go
+++ b/provider/aws.go
@@ -173,7 +173,9 @@ func (p AwsProfiles) listRegions() []string {
 	}
 	log.Debugf("Using profile: %s, ARN: %s, IsRole:%t", p.Name, p.Arn, p.IsRole)
 	for _, r := range result.Regions {
-		reg = append(reg, *r.RegionName)
+		if r.OptInStatus != nil && (*r.OptInStatus == "opted-in" || *r.OptInStatus == "not-required") {
+			reg = append(reg, *r.RegionName)
+		}
 	}
 
 	return reg


### PR DESCRIPTION
… are scanned.
Update listRegions() to filter by OptInStatus
Region Filtering:
Now only regions with OptInStatus of "opted-in" or "not-required" are scanned for EKS clusters.